### PR TITLE
Merging Cancel Order Security Fixes into main branch

### DIFF
--- a/backend/src/main/java/com/packora/backend/controller/OrderController.java
+++ b/backend/src/main/java/com/packora/backend/controller/OrderController.java
@@ -29,15 +29,6 @@ import java.util.List;
  * │ GET    /api/orders/{id}                                 │ Get single order by ID        │
  * │ PUT    /api/orders/{id}/status                          │ Update order status (Admin)   │
  * │ PUT    /api/orders/{id}/cancel                          │ Cancel an order               │
- * └─────────────────────────────────────────────────────────┴───────────────────────────────┘
- *
- * NOTE on authentication:
- * At this stage of the project, authentication via JWT has not been implemented.
- * The /me endpoint uses a ?userId= query param as a temporary stand-in.
- * Once Spring Security + JWT is wired up:
- *   1. Remove the userId query param from GET /me
- *   2. Extract principal from SecurityContextHolder in the service
- *   3. Add @PreAuthorize("hasRole('ADMIN')") to admin-only endpoints
  */
 @RestController
 @RequestMapping("/api/orders")
@@ -155,8 +146,10 @@ public class OrderController {
      * No request body needed — the action is implied by the endpoint.
      */
     @PutMapping("/{id}/cancel")
-    public ResponseEntity<OrderResponse> cancelOrder(@PathVariable Long id) {
-        log.info("[OrderController] PUT /api/orders/{}/cancel", id);
-        return ResponseEntity.ok(orderService.cancelOrder(id));
+    public ResponseEntity<OrderResponse> cancelOrder(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetailsImpl principal) {
+        log.info("[OrderController] PUT /api/orders/{}/cancel — userId={}", id, principal.getId());
+        return ResponseEntity.ok(orderService.cancelOrder(id, principal.getId()));
     }
 }

--- a/backend/src/main/java/com/packora/backend/service/OrderService.java
+++ b/backend/src/main/java/com/packora/backend/service/OrderService.java
@@ -48,6 +48,7 @@ public interface OrderService {
     /**
      * Cancel an order.
      * Only orders in PENDING or PROCESSING state can be cancelled.
+     * The caller's userId must match the order's owner.
      */
-    OrderResponse cancelOrder(Long orderId);
+    OrderResponse cancelOrder(Long orderId, Long userId);
 }

--- a/backend/src/main/java/com/packora/backend/service/OrderServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/OrderServiceImpl.java
@@ -203,8 +203,14 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional
-    public OrderResponse cancelOrder(Long orderId) {
+    public OrderResponse cancelOrder(Long orderId, Long userId) {
         Order order = findOrderOrThrow(orderId);
+
+        // Ownership check: only the order's owner can cancel it
+        if (!order.getUser().getId().equals(userId)) {
+            throw new org.springframework.security.access.AccessDeniedException(
+                    "You are not authorized to cancel this order.");
+        }
 
         if (!CANCELLABLE_STATUSES.contains(order.getStatus())) {
             throw new IllegalStateException(
@@ -213,7 +219,7 @@ public class OrderServiceImpl implements OrderService {
                     + ". Only PENDING or PROCESSING orders can be cancelled.");
         }
 
-        log.info("[OrderService] Cancelling order {}", orderId);
+        log.info("[OrderService] Cancelling order {} for userId={}", orderId, userId);
         order.setStatus(OrderStatus.CANCELLED);
         return toOrderResponse(orderRepository.save(order));
     }


### PR DESCRIPTION
- cancelOrder(Long orderId) → cancelOrder(Long orderId, Long userId) — the service now verifies order.getUser().getId().equals(userId) before cancelling. If it doesn't match, it throws AccessDeniedException (Spring Security maps this to 403 Forbidden)
- Controller now injects @AuthenticationPrincipal UserDetailsImpl principal and passes principal.getId() to the service
