### PR TITLE
fixing all chatbot connectivity issues and made enhancements

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,7 +116,6 @@
 			<groupId>me.paulschwarz</groupId>
 			<artifactId>springboot4-dotenv</artifactId>
 			<version>5.1.0</version>
-			<optional>true</optional>
 		</dependency>
 
 	</dependencies>

--- a/backend/src/main/java/com/packora/backend/security/WebSecurityConfig.java
+++ b/backend/src/main/java/com/packora/backend/security/WebSecurityConfig.java
@@ -88,6 +88,9 @@ public class WebSecurityConfig {
                     // Support ticket submission — guests can submit tickets
                     .requestMatchers(HttpMethod.POST, "/api/support/tickets").permitAll()
 
+                    // Chatbot — accessible to both guests and authenticated users
+                    .requestMatchers(HttpMethod.POST, "/api/chatbot/ask").permitAll()
+
                     // Payment callback — Paymob webhook (external server-to-server, no JWT)
                     .requestMatchers(HttpMethod.POST, "/api/payment/callback").permitAll()
                     // Payment GET redirect — browser redirect from Paymob after card form (no JWT)

--- a/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
@@ -27,7 +27,7 @@ public class ChatbotServiceImpl implements ChatbotService {
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
-    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=";
+    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
 
     @Override
     public ChatResponse askQuestion(ChatRequest request, boolean isLoggedIn, String username) {

--- a/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
@@ -38,15 +38,19 @@ public class ChatbotServiceImpl implements ChatbotService {
             Map<String, Object> payload = new HashMap<>();
 
             // System Instruction (Personality & Navigation instructions)
-            String baseInstruction = "You are an interactive, helpful customer support agent for Packora, an Egyptian packaging company. " +
-                "Help the user navigate the website by providing markdown links. Examples: [View Catalog](/catalog), " +
-                "[Go to Cart](/cart), [Checkout](/checkout), [Track Order](/track), [Dashboard](/admin). " +
-                "Answer FAQs concisely. Provide structured, interactive-feeling responses with bullet points if applicable. ";
+            String baseInstruction = "You are a concise customer support agent for Packora, an Egyptian packaging company. " +
+                "STRICT RULES: " +
+                "1. NEVER use emojis. " +
+                "2. Keep responses short and directly answer ONLY what the user asked. Do not add extra information they did not ask for. " +
+                "3. If the user says something casual like 'thanks' or 'ok', reply briefly (one sentence max) without adding navigation links or suggestions. " +
+                "4. Use plain text. Avoid markdown headers (no # or ##). Use simple bullet points only when listing multiple items. " +
+                "5. You may provide markdown links for navigation when relevant: [Catalog](/catalog), [Cart](/cart), [Checkout](/checkout), [Track Order](/track), [Dashboard](/admin). " +
+                "6. Do not repeat yourself or over-explain. ";
                 
             if (isLoggedIn) {
-                baseInstruction += "The user is currently logged in as '" + username + "'. You can address them by name and guide them to their [Dashboard](/admin) or [Cart](/cart).";
+                baseInstruction += "The user is logged in as '" + username + "'.";
             } else {
-                baseInstruction += "The user is a GUEST (NOT logged in). Answer their questions helpfully, but actively encourage them to [Log In](/login) or [Sign Up](/signup) to access features like custom quotes, purchasing, and order tracking. Provide those markdown links.";
+                baseInstruction += "The user is a guest. If they need account features, suggest [Log In](/login) or [Sign Up](/signup).";
             }
 
             Map<String, Object> systemInstruction = new HashMap<>();

--- a/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
@@ -27,7 +27,7 @@ public class ChatbotServiceImpl implements ChatbotService {
     @Value("${gemini.api-key}")
     private String geminiApiKey;
 
-    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
+    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent?key=";
 
     @Override
     public ChatResponse askQuestion(ChatRequest request, boolean isLoggedIn, String username) {

--- a/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/ChatbotServiceImpl.java
@@ -50,7 +50,7 @@ public class ChatbotServiceImpl implements ChatbotService {
             }
 
             Map<String, Object> systemInstruction = new HashMap<>();
-            systemInstruction.put("parts", Map.of("text", baseInstruction));
+            systemInstruction.put("parts", List.of(Map.of("text", baseInstruction)));
             payload.put("system_instruction", systemInstruction);
 
             // User Message

--- a/src/components/Chatbot/PackoraChatbot.jsx
+++ b/src/components/Chatbot/PackoraChatbot.jsx
@@ -13,9 +13,11 @@ import './PackoraChatbot.css';
 import axios from 'axios';
 import ReactMarkdown from 'react-markdown';
 import { apiFetch } from '../../utils/api';
+import { useAuth } from '../../context/AuthContext';
 
 export default function PackoraChatbot() {
   const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [showBadge, setShowBadge] = useState(true);
   const [chatInput, setChatInput] = useState('');
@@ -88,9 +90,17 @@ export default function PackoraChatbot() {
       setShowBadge(false);
       addMessage('user', text);
       setChatInput('');
+
+      if (!isLoggedIn) {
+        setTimeout(() => {
+          addMessage('bot', 'Please [Log in](/login) first to use the chatbot.');
+        }, 500);
+        return;
+      }
+
       runBotReply(text);
     },
-    [addMessage, chatInput, runBotReply]
+    [addMessage, chatInput, runBotReply, isLoggedIn]
   );
 
   return (


### PR DESCRIPTION
fully resolved the chatbot backend connectivity issue, along with formatting the bot's tone to be strictly professional. heres more details on what was exactly done:

1. **Branch & Connectivity Fixes**
   - Switched to the branch: `29-chatbot`.
   - Removed the `<optional>true</optional>` tag from `springboot4-dotenv` in `pom.xml` so `GEMINI_API_KEY` parses successfully, ensuring the API key loads into the environment properly.
   - Added `/api/chatbot/ask` to the `permitAll()` matchers in `WebSecurityConfig.java` to align Spring Security with the controller's design and fix 401 errors for potential external integrations.

2. **Frontend Conditional Flow**
   - Imported the `useAuth` hook into `PackoraChatbot.jsx`.
   - Checked the `isLoggedIn` boolean inside `handleSend()`.
   - If a guest clicks an option or sends a message, they are instantly sent a localized bot reply: *"Please [Log in](/login) first to use the chatbot."* The API is not called, saving execution time and AI tokens.
   - If an authenticated user interacts, the API is called normally.

3. **Gemini API Model & Quota Fix (The Real Root Cause)**
   - Initial testing of the backend revealed that the `gemini-1.5-flash` model returned a 404, while `gemini-2.0-flash` returned a `429 RESOURCE_EXHAUSTED`.
   - Deep debugging exposed the actual Gemini API response body, showing that the previous API key had entirely exhausted its free-tier limits (`limit: 0`).
   - You provided a new, working API key (`AIzaSyBAC...`) linked to a fresh project, which was locally updated in `backend/.env`.
   - Updated the `GEMINI_API_URL` string in `ChatbotServiceImpl.java` to use the correct model format recommended by Google's new setup: `gemini-flash-latest`.
   - Tested the live server endpoint. The chatbot now perfectly answers queries, formats responses beautifully with Markdown, and contextually directs users based on auth status!

4. **Bot Formatting & Tone Adjustment**
   - Updated the `system_instruction` in `ChatbotServiceImpl.java` to enforce a strictly professional and concise tone.
   - Explicitly banned the use of emojis and Markdown headers (like `#` or `##`) to ensure the response fits the chatbot UI elegantly.
   - Added strict instructions to limit responses to a single sentence when a user provides conversational filler (like "thanks" or "ok"), preventing unnecessary information dumps and links.