### PR TITLE
Carts Transactional Read-Only Fix

### DIFF
--- a/backend/src/main/java/com/packora/backend/service/CartServiceImpl.java
+++ b/backend/src/main/java/com/packora/backend/service/CartServiceImpl.java
@@ -40,7 +40,7 @@ public class CartServiceImpl implements CartService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public CartResponse getCartForUser(Long userId) {
         Cart cart = getOrCreateCart(userId);
         return mapToResponse(cart);


### PR DESCRIPTION
Fixed a potential runtime failure in CartServiceImpl where requesting the user's cart could throw an exception on strict databases due to writing data within a read-only transaction.